### PR TITLE
[FIX] Skip header row when reading datasets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ export -f getit
 [ ! -e ${out} ] && mkdir -p ${out}
 
 {
+    # We need to read the first line and discard it to skip the header row
+    read
     # Ensure last line is read even if file does not end with newline
     # See: https://stackoverflow.com/a/12916758
     while read -r dataset || [ -n "$dataset" ];


### PR DESCRIPTION
Fixes #1

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
