### PR TITLE
[FIX] Allow any user to write to .cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir datalad && \
-    git config --global --add user.name 'Ford Escort' && \
-    git config --global --add user.email 42@H2G2.com && \
     datalad wtf
+
+# We must allow write permission to the /.cache directory
+# for any user that runs the container
+RUN mkdir -p /.cache && chmod 777 /.cache
 
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && \
 
 # We must allow write permission to the /.cache directory
 # for any user that runs the container
-RUN mkdir -p /.cache && chmod 777 /.cache
+RUN mkdir -p /.cache && chmod +w /.cache
 
 COPY ./entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]   

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && \
 
 # We must allow write permission to the /.cache directory
 # for any user that runs the container
-RUN mkdir -p /.cache && chmod +w /.cache
+RUN mkdir -p /.cache && chmod ugo+rw /.cache
 
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]   


### PR DESCRIPTION
Because we now allow users to run the docker image with the -u flag, we need to also give any user the ability to write to the /.cache directory. The arbitrary UID user won't have a home directory in the container, and so will default to use / as their home - where they then don't have write permission by default

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
